### PR TITLE
Fix use of declspec stuff on Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(xxd ${CMAKE_CURRENT_SOURCE_DIR}/src/xxd.c)
 
-add_library(libxxd SHARED ${CMAKE_CURRENT_SOURCE_DIR}/src/xxd.cpp)
+add_library(libxxd SHARED
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/xxd.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/xxd.h
+	${CMAKE_CURRENT_SOURCE_DIR}/include/xxd.in
+	${CMAKE_CURRENT_SOURCE_DIR}/cmake/EmbedFile.cmake)
 set_property(TARGET libxxd PROPERTY CXX_STANDARD 11)
 target_include_directories(libxxd PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set_target_properties(libxxd PROPERTIES OUTPUT_NAME xxd)
@@ -24,14 +28,14 @@ macro(xxd_embed FILE_KEY FILE_PATH SOURCES)
 		COMMAND $<TARGET_FILE:xxd> -i < ${FILE_PATH} > ${FILE_HEX}
 		COMMENT "Generating hex representation of ${FILE_PATH} file content"
 		DEPENDS ${FILE_PATH} xxd)
-	set_source_files_properties("${FILE_HEX}" PROPERTIES GENERATED TRUE) 
+	set_source_files_properties("${FILE_HEX}" PROPERTIES GENERATED TRUE)
 	set(EMBED_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${FILE_KEY}.cpp")
 	add_custom_command(
 		OUTPUT ${EMBED_FILE_PATH}
 		COMMAND ${CMAKE_COMMAND} -DCMAKE_CURRENT_INCLUDE_DIR=${CMAKE_CURRENT_INCLUDE_DIR} -DFILE_HEX=${FILE_HEX} -DFILE_KEY=${FILE_KEY} -DFILE_PATH=${FILE_PATH} -DEMBED_FILE_PATH=${EMBED_FILE_PATH} -P ${CMAKE_CURRENT_INCLUDE_DIR}/../cmake/EmbedFile.cmake
 		COMMENT "Embedding file ${FILE_PATH}"
 		DEPENDS ${FILE_HEX} "${CMAKE_CURRENT_INCLUDE_DIR}/xxd.in")
-	set_source_files_properties("${EMBED_FILE_PATH}" PROPERTIES GENERATED TRUE) 
+	set_source_files_properties("${EMBED_FILE_PATH}" PROPERTIES GENERATED TRUE)
 
 	# Submit the resulting source file for compilation
 	list(APPEND ${SOURCES} ${EMBED_FILE_PATH})

--- a/include/xxd.h
+++ b/include/xxd.h
@@ -2,7 +2,7 @@
 #define XXD_H
 
 #ifdef _WIN32
-#ifdef incbin_EXPORTS
+#ifdef libxxd_EXPORTS
 #define XXD_EMBED_API __declspec(dllexport)
 #else
 #define XXD_EMBED_API __declspec(dllimport)
@@ -16,10 +16,10 @@
 namespace xxd {
 
 // Add an entry to the index of embedded resources (internal).
-void XXD_EMBED_API add(const std::string& name, const char* content, size_t size, const std::string& mime);
+XXD_EMBED_API void add(const std::string& name, const char* content, size_t size, const std::string& mime);
 
 // Get an entry from the index of embedded resources.
-const char* XXD_EMBED_API get(const std::string& name, size_t* size = nullptr, std::string* mime = nullptr);
+XXD_EMBED_API const char* get(const std::string& name, size_t* size = nullptr, std::string* mime = nullptr);
 
 } // namespace xxd
 


### PR DESCRIPTION
Fix macro for declspec to use the correct CMake generated macro, this is already correct in res_embed
Move XXD_EMBED_API macro to the correct place
Add .h and .in files to the project so you can see the in Visual Studio